### PR TITLE
Print durations instead of amounts

### DIFF
--- a/header/utility.hpp
+++ b/header/utility.hpp
@@ -57,6 +57,12 @@ void erase(std::vector<T>& vec, size_t begin, size_t end) {
   vec.erase(vec.begin() + begin, vec.begin() + end);
 }
 
+template <class Unit>
+Unit now() {
+  auto ts = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<Unit>(ts);
+}
+
 void exit(const std::string& msg = "", const caf::error& err = caf::none);
 
 void exit(const caf::error& err);

--- a/src/blank_streaming_tcp.cpp
+++ b/src/blank_streaming_tcp.cpp
@@ -81,7 +81,6 @@ behavior accumulator_actor(stateful_actor<accumulator_state>* self,
 
 struct source_state {
   payload p;
-  size_t streaming_amount = 0;
 };
 
 behavior source_actor(stateful_actor<source_state>* self, actor sink,
@@ -90,7 +89,6 @@ behavior source_actor(stateful_actor<source_state>* self, actor sink,
   self->link_to(sink);
   return {
     [=](init_atom init) {
-      self->state.streaming_amount = streaming_amount;
       self->state.p.resize(payload_size);
       self->send(sink, init, streaming_amount);
       self->send(self, send_atom_v);

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -18,6 +18,7 @@
 
 #include "utility.hpp"
 
+#include <chrono>
 #include <cstdlib>
 #include <string>
 #include <utility>


### PR DESCRIPTION
This PR refactors the benchmarks to print the durations instead of amounts of bytes/messages as result.